### PR TITLE
Lower platform level to iOS 14 / tvOS 14

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -5,11 +5,11 @@ import PackageDescription
 let package = Package(
     name: "swift-gzip",
     platforms: [
-        .iOS(.v15),
-        .tvOS(.v15),
+        .iOS(.v14),
+        .tvOS(.v14),
         .visionOS(.v1),
         .macOS(.v12),
-        .macCatalyst(.v15),
+        .macCatalyst(.v14),
         .watchOS(.v8)
     ],
     products: [


### PR DESCRIPTION
Hi Mihaim,

Thanks for your awesome library! I'm developing an iPhone app that targets iOS 14. It would profit from using streaming Gzip decompression, as it requires less memory.

I've verified that your library builds and passes all tests with the lowered platform requirements for iOS 14, tvOS 14, and Mac Catalyst 14. I could also integrate the library without issues into my iOS 14 app. The library performs its desired function on an iPhone running iOS 14. Can we consider lowering the platform limits, or do you have a specific reason to stay on iOS 15?

Best
Lukas