### PR TITLE
Make CZlib available for Static Linux SDK

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -2,64 +2,40 @@
 
 import PackageDescription
 
-var targets: [PackageDescription.Target] = []
-
-// Declare CZlib only on Linux.
-#if os(Linux)
-targets.append(
-    .systemLibrary(
-        name: "CZlib",
-        path: "Sources/CZlib"
-    )
-)
-#endif
-
-var swiftGzipDependencies: [Target.Dependency] = []
-#if os(Linux)
-swiftGzipDependencies.append(.target(name: "CZlib"))
-#endif
-
-var swiftGzipLinkerSettings: [LinkerSetting] = []
-#if !os(Linux)
-// On Linux, CZlib's modulemap already links `-lz`.
-swiftGzipLinkerSettings.append(.linkedLibrary("z"))
-#endif
-
-targets.append(
-    .target(
-        name: "SwiftGzip",
-        dependencies: swiftGzipDependencies,
-        path: "Sources",
-        resources: [.copy("Resources/PrivacyInfo.xcprivacy")],
-        swiftSettings: [.enableExperimentalFeature("StrictConcurrency")],
-        linkerSettings: swiftGzipLinkerSettings
-    )
-)
-
-targets.append(
-    .testTarget(
-        name: "SwiftGzipTests",
-        dependencies: [.target(name: "SwiftGzip")],
-        resources: [
-            .copy("Resources/test.png"),
-            .copy("Resources/test.png.gz")
-        ]
-    )
-)
-
 let package = Package(
     name: "swift-gzip",
     platforms: [
         .iOS(.v14),
-        .tvOS(.v14),
-        .visionOS(.v1),
         .macOS(.v12),
         .macCatalyst(.v14),
+        .tvOS(.v14),
+        .visionOS(.v1),
         .watchOS(.v8)
     ],
     products: [
         .library(name: "SwiftGzip", targets: ["SwiftGzip"])
     ],
-    targets: targets,
+    targets: [
+        .target(
+            name: "SwiftGzip",
+            dependencies: [.target(name: "CZlib", condition: .when(platforms: [.linux]))],
+            path: "Sources",
+            resources: [.copy("Resources/PrivacyInfo.xcprivacy")],
+            swiftSettings: [.enableExperimentalFeature("StrictConcurrency")],
+            linkerSettings: [.linkedLibrary("z", .when(platforms: [.iOS, .macOS, .macCatalyst, .tvOS, .visionOS, .watchOS]))]
+        ),
+        .testTarget(
+            name: "SwiftGzipTests",
+            dependencies: [.target(name: "SwiftGzip")],
+            resources: [
+                .copy("Resources/test.png"),
+                .copy("Resources/test.png.gz")
+            ]
+        ),
+        .systemLibrary(
+            name: "CZlib",
+            path: "Sources/CZlib"
+        )
+    ],
     swiftLanguageModes: [.v6]
 )

--- a/Package@swift-5.10.swift
+++ b/Package@swift-5.10.swift
@@ -2,64 +2,40 @@
 
 import PackageDescription
 
-var targets: [PackageDescription.Target] = []
-
-// Declare CZlib only on Linux.
-#if os(Linux)
-targets.append(
-    .systemLibrary(
-        name: "CZlib",
-        path: "Sources/CZlib"
-    )
-)
-#endif
-
-var swiftGzipDependencies: [Target.Dependency] = []
-#if os(Linux)
-swiftGzipDependencies.append(.target(name: "CZlib"))
-#endif
-
-var swiftGzipLinkerSettings: [LinkerSetting] = []
-#if !os(Linux)
-// On Linux, CZlib's modulemap already links `-lz`.
-swiftGzipLinkerSettings.append(.linkedLibrary("z"))
-#endif
-
-targets.append(
-    .target(
-        name: "SwiftGzip",
-        dependencies: swiftGzipDependencies,
-        path: "Sources",
-        resources: [.copy("Resources/PrivacyInfo.xcprivacy")],
-        swiftSettings: [.enableExperimentalFeature("StrictConcurrency")],
-        linkerSettings: swiftGzipLinkerSettings
-    )
-)
-
-targets.append(
-    .testTarget(
-        name: "SwiftGzipTests",
-        dependencies: [.target(name: "SwiftGzip")],
-        resources: [
-            .copy("Resources/test.png"),
-            .copy("Resources/test.png.gz")
-        ]
-    )
-)
-
 let package = Package(
     name: "swift-gzip",
     platforms: [
-        .iOS(.v15),
-        .tvOS(.v15),
-        .visionOS(.v1),
+        .iOS(.v14),
         .macOS(.v12),
-        .macCatalyst(.v15),
+        .macCatalyst(.v14),
+        .tvOS(.v14),
+        .visionOS(.v1),
         .watchOS(.v8)
     ],
     products: [
         .library(name: "SwiftGzip", targets: ["SwiftGzip"])
     ],
-    targets: targets,
-    swiftLanguageVersions: [.v5]
+    targets: [
+        .target(
+            name: "SwiftGzip",
+            dependencies: [.target(name: "CZlib", condition: .when(platforms: [.linux]))],
+            path: "Sources",
+            resources: [.copy("Resources/PrivacyInfo.xcprivacy")],
+            swiftSettings: [.enableExperimentalFeature("StrictConcurrency")],
+            linkerSettings: [.linkedLibrary("z", .when(platforms: [.iOS, .macOS, .macCatalyst, .tvOS, .visionOS, .watchOS]))]
+        ),
+        .testTarget(
+            name: "SwiftGzipTests",
+            dependencies: [.target(name: "SwiftGzip")],
+            resources: [
+                .copy("Resources/test.png"),
+                .copy("Resources/test.png.gz")
+            ]
+        ),
+        .systemLibrary(
+            name: "CZlib",
+            path: "Sources/CZlib"
+        )
+    ],
+    swiftLanguageModes: [.v5]
 )

--- a/Sources/CZlib/module.modulemap
+++ b/Sources/CZlib/module.modulemap
@@ -1,5 +1,5 @@
 module CZlib [system] {
-  header "/usr/include/zlib.h"
+  header "zlib_shim.h"
   link "z"
   export *
 }

--- a/Sources/CZlib/zlib_shim.h
+++ b/Sources/CZlib/zlib_shim.h
@@ -1,0 +1,3 @@
+#pragma once
+
+#include <zlib.h>


### PR DESCRIPTION
Added `zlib_shim.h` to fix build failures when using [Static Linux SDK](https://www.swift.org/documentation/articles/static-linux-getting-started.html).

While doing so, cleaned up `Package.swift` syntax and aligned supported platform versions between `Package.swift` and `Package@swift-5.10.swift`.